### PR TITLE
[sc-9353] Remove processing_v2 feature flag

### DIFF
--- a/features-v2.json
+++ b/features-v2.json
@@ -107,9 +107,6 @@
   "application_manage-entities": {
     "rollout": 100
   },
-  "application_nucliadb_processing_v2": {
-    "rollout": 100
-  },
   "application_kb-anonymization": {
     "rollout": 100
   },


### PR DESCRIPTION
To be merged only once https://app.shortcut.com/flaps/story/9353/remove-processing-v2-feature-flag is promoted to production.