### PR TITLE
Updating feature flags for authorized usage

### DIFF
--- a/features-v2.json
+++ b/features-v2.json
@@ -256,6 +256,12 @@
       "account_id_md5": []
     }
   },
+  "application_anonymization": {
+    "rollout": 100,
+    "variants": {
+      "account_id_md5": []
+    }
+  },
   "application_synonyms": {
     "rollout": 100,
     "variants": {

--- a/features-v2.json
+++ b/features-v2.json
@@ -210,7 +210,10 @@
     "rollout": 0
   },
   "application_llm-prompt-lab": {
-    "rollout": 100
+    "rollout": 100,
+    "variants": {
+      "account_id_md5": []
+    }
   },
   "application_view-nua-activity": {
     "rollout": 0
@@ -242,10 +245,22 @@
     }
   },
   "application_allow-kb-management-from-nua-key": {
-    "rollout": 100
+    "rollout": 100,
+    "variants": {
+      "account_id_md5": []
+    }
   },
   "application_summarization": {
-    "rollout": 0
+    "rollout": 0,
+    "variants": {
+      "account_id_md5": []
+    }
+  },
+  "application_synonyms": {
+    "rollout": 0,
+    "variants": {
+      "account_id_md5": []
+    }
   },
   "core_services_idp_regional_stop_push_stats": {
     "rollout": 0

--- a/features-v2.json
+++ b/features-v2.json
@@ -257,7 +257,7 @@
     }
   },
   "application_synonyms": {
-    "rollout": 0,
+    "rollout": 100,
     "variants": {
       "account_id_md5": []
     }

--- a/features-v2.json
+++ b/features-v2.json
@@ -225,7 +225,7 @@
     "rollout": 0
   },
   "application_user-prompts": {
-    "rollout": 0,
+    "rollout": 100,
     "variants": {
       "account_id_md5": [
         "d90e71d72010b80cf0b5c3da39525c08",
@@ -251,7 +251,7 @@
     }
   },
   "application_summarization": {
-    "rollout": 0,
+    "rollout": 100,
     "variants": {
       "account_id_md5": []
     }

--- a/features-v2.json
+++ b/features-v2.json
@@ -212,18 +212,6 @@
   "application_llm-prompt-lab": {
     "rollout": 100
   },
-  "application_manage-entities": {
-    "rollout": 100
-  },
-  "application_kb-anonymization": {
-    "rollout": 100
-  },
-  "application_rag-hierarchy": {
-    "rollout": 100
-  },
-  "application_sync": {
-    "rollout": 100
-  },
   "application_view-nua-activity": {
     "rollout": 0
   },
@@ -232,12 +220,6 @@
   },
   "application_training_ner": {
     "rollout": 0
-  },
-  "application_download-desktop-app": {
-    "rollout": 100
-  },
-  "application_upload-q-and-a": {
-    "rollout": 100
   },
   "application_user-prompts": {
     "rollout": 0,
@@ -260,9 +242,6 @@
     }
   },
   "application_allow-kb-management-from-nua-key": {
-    "rollout": 100
-  },
-  "application_new-pricing": {
     "rollout": 100
   },
   "application_summarization": {


### PR DESCRIPTION
**Frontend feature flags are used for two cases**:
- unstable features are under feature flag, usually hidden in prod (rollout: 0) but can be enabled for some client using `account_id_md5` variant
- authorized features are not under feature flag anymore (rollout: 100), but they require certain account type to access the feature. We can also enable the feature for some clients using `account_id_md5`.
