### PR TITLE
Enable OpenAI embeddings in prod

### DIFF
--- a/features-v2.json
+++ b/features-v2.json
@@ -74,9 +74,6 @@
     "rollout": 0,
     "variants": {
       "model": [
-        "text-embedding-3-small",
-        "text-embedding-3-large",
-        "bge-large-en-v1-5",
         "multilingual-2024-05-06"
       ]
     }
@@ -206,6 +203,9 @@
   },
   "application_knowledge-graph": {
     "rollout": 0
+  },
+  "application_openai-models": {
+    "rollout": 100
   },
   "application_gecko-model": {
     "rollout": 100


### PR DESCRIPTION
Enable openAI embeds in prod by removing them from our disabled list and adding the `application_openai-models` flag, as indicated by Eric here (https://nucliacom.slack.com/archives/C06CZ9Z2CNL/p1715008661014199?thread_ts=1712241252.970709&cid=C06CZ9Z2CNL)

Also removed the english model that was removed in favor of snowflake