### PR TITLE
Cleanup semantic model FF (frontend)

### DIFF
--- a/features-v2.json
+++ b/features-v2.json
@@ -254,12 +254,6 @@
   "application_knowledge-graph": {
     "rollout": 0
   },
-  "application_openai-models": {
-    "rollout": 100
-  },
-  "application_gecko-model": {
-    "rollout": 100
-  },
   "application_github-signin": {
     "rollout": 0
   },


### PR DESCRIPTION
Gecko and OpenAI semantic models are now in prod.

To be merged once they are removed from frontend code as well.