### PR TITLE
Remove eu-south-2-1 zone

### DIFF
--- a/features-v2.json
+++ b/features-v2.json
@@ -237,7 +237,7 @@
   "application_zones": {
     "rollout": 100,
     "variants": {
-      "blocklist": ["aws-eu-south-2-1"]
+      "blocklist": []
     }
   },
   "application_allow-kb-management-from-nua-key": {


### PR DESCRIPTION
This pull request includes a minor update to the `features-v2.json` file. The change removes the `aws-eu-south-2-1` entry from the `blocklist` array under the `application_zones` configuration, leaving the `blocklist` empty.