### PR TITLE
Add cache invalidation for feature flag file

### DIFF
--- a/.github/workflows/push-to-cdn.yaml
+++ b/.github/workflows/push-to-cdn.yaml
@@ -39,3 +39,17 @@ jobs:
         with:
           path: features-v2.json
           destination: ncl-cdn-gcp-global-stage-1/features
+                
+      - name: Invalidate CDN cache stage
+        env:
+          GCP_PROJECT: nuclia-gcp-global-stage-1
+          URL_MAP_NAME: ncl-cdn-gcp-global-stage-1
+        run: |
+          gcloud compute url-maps invalidate-cdn-cache ${URL_MAP_NAME} --path "/features/features-v2.json" --global --project ${GCP_PROJECT}
+
+      - name: Invalidate CDN cache stage
+        env:
+          GCP_PROJECT: nuclia-gcp-global-prod-1
+          URL_MAP_NAME: ncl-cdn-gcp-global-prod-1
+        run: |
+          gcloud compute url-maps invalidate-cdn-cache ${URL_MAP_NAME} --path "/features/features-v2.json" --global --project ${GCP_PROJECT}


### PR DESCRIPTION
This pull request updates the `.github/workflows/push-to-cdn.yaml` file to include steps for invalidating the CDN cache after deploying a new version of `features-v2.json`. This ensures that the latest changes are reflected immediately in both staging and production environments.

Workflow enhancements:

* Added a step to invalidate the CDN cache for the staging environment using `gcloud compute url-maps invalidate-cdn-cache`. This ensures that `/features/features-v2.json` is refreshed globally in the `nuclia-gcp-global-stage-1` project.
* Added a step to invalidate the CDN cache for the production environment using the same approach, targeting the `nuclia-gcp-global-prod-1` project.