### PR TITLE
Revert "Disable regional KB and Nuakey edit/delete AND stop pushing stats"

### DIFF
--- a/features-v2.json
+++ b/features-v2.json
@@ -299,20 +299,10 @@
     }
   },
   "core_services_idp_regional_stop_push_stats": {
-    "rollout": 0,
-    "variants": {
-      "environment": [
-        "stage"
-      ]
-    }
+    "rollout": 0
   },
   "core_services_idp_regional_stop_create_or_edit_kbs_and_nuakeys": {
-    "rollout": 0,
-    "variants": {
-      "environment": [
-        "europe-1-stage"
-      ]
-    }
+    "rollout": 0
   },
   "application_hugging-face-semantic": {
     "rollout": 100,


### PR DESCRIPTION
This pull request includes a cleanup of the `features-v2.json` file by simplifying feature flag configurations. The changes remove unnecessary `variants` fields for specific feature flags.

### Cleanup of feature flag configurations:

* [`features-v2.json`](diffhunk://#diff-6de31510e37b284f23ff1215d45cbc690915d3b0c2ebb7e3472dbb7fcc2d462dL302-R305): Removed the `variants` field from the `core_services_idp_regional_stop_push_stats` and `core_services_idp_regional_stop_create_or_edit_kbs_and_nuakeys` feature flags, leaving only the `rollout` field. This simplifies the configuration.

Reverts nuclia/status#396