### PR TITLE
Global AWS Migration - Disable regional push and regional edits

### DIFF
--- a/features-v2.json
+++ b/features-v2.json
@@ -295,10 +295,20 @@
     }
   },
   "core_services_idp_regional_stop_push_stats": {
-    "rollout": 0
+    "rollout": 0,
+    "variants": {
+      "environment": [
+        "prod"
+      ]
+    }
   },
   "core_services_idp_regional_stop_create_or_edit_kbs_and_nuakeys": {
-    "rollout": 0
+    "rollout": 0,
+    "variants": {
+      "environment": [
+        "prod"
+      ]
+    }
   },
   "application_hugging-face-semantic": {
     "rollout": 100,


### PR DESCRIPTION
This pull request updates the configuration for two feature flags in `features-v2.json` to specify that their variants are limited to the `prod` environment. The rollout percentages remain unchanged.

Feature flag configuration:

* Added an `environment` variant (set to `prod`) for the `core_services_idp_regional_stop_push_stats` feature flag.
* Added an `environment` variant (set to `prod`) for the `core_services_idp_regional_stop_create_or_edit_kbs_and_nuakeys` feature flag.