### PR TITLE
Push features flags to S3 CDN

### DIFF
--- a/.github/workflows/push-to-cdn.yaml
+++ b/.github/workflows/push-to-cdn.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
 
+      #####################################################################
+      ## START: After the CDN is moved to cloudfront, all of this can be removed
+      #####################################################################
       - name: Authenticate to Google Cloud
         id: gcp-auth
         uses: google-github-actions/auth@v2
@@ -28,18 +31,18 @@ jobs:
           service_account: "${{ env.GCP_SERVICE_ACCOUNT }}"
           token_format: access_token
 
-      - name: Push to CDN
+      - name: Push to stage CDN
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          path: features-v2.json
+          destination: ncl-cdn-gcp-global-stage-1/features
+
+      - name: Push to prod CDN
         uses: google-github-actions/upload-cloud-storage@v2
         with:
           path: features-v2.json
           destination: ncl-cdn-gcp-global-prod-1/features
 
-      - name: Push to CDN
-        uses: google-github-actions/upload-cloud-storage@v2
-        with:
-          path: features-v2.json
-          destination: ncl-cdn-gcp-global-stage-1/features
-                
       - name: Invalidate CDN cache stage
         env:
           GCP_PROJECT: nuclia-gcp-global-stage-1
@@ -53,3 +56,45 @@ jobs:
           URL_MAP_NAME: ncl-cdn-gcp-global-prod-1
         run: |
           gcloud compute url-maps invalidate-cdn-cache ${URL_MAP_NAME} --path "/features/features-v2.json" --global --project ${GCP_PROJECT}
+
+      #####################################################################
+      ## END: After the CDN is moved to cloudfront, all of this can be removed
+      #####################################################################
+
+      - name: Configure AWS credentials - Stage
+        uses: aws-actions/configure-aws-credentials@v4
+        env:
+          AWS_IAM_ROLE: 'arn:aws:iam::512378127709:role/cdn-sync-aws-global-stage-1'
+        with:
+          role-to-assume: '${{ env.AWS_IAM_ROLE }}'
+          aws-region: eu-central-1
+
+      - name: Upload to S3 - Stage
+        run: |
+          aws s3 cp features-v2.json s3://nuclia-cdn-aws-global-stage-1/features/
+
+      - name: Invalidate cloudfront cache - Stage
+        env:
+          AWS_REGION: us-east-1
+          CLOUDFRONT_DISTRIBUTION_ID: E1C4WOHLRMW4OS
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DISTRIBUTION_ID} --paths "/features/features-v2.json"
+
+      - name: Configure AWS credentials - Prod
+        uses: aws-actions/configure-aws-credentials@v4
+        env:
+          AWS_IAM_ROLE: 'arn:aws:iam::097564615940:role/cdn-sync-aws-global-prod-1'
+        with:
+          role-to-assume: '${{ env.AWS_IAM_ROLE }}'
+          aws-region: eu-central-1
+
+      - name: Upload to S3 - Prod
+        run: |
+          aws s3 cp features-v2.json s3://nuclia-cdn-aws-global-prod-1/features/
+
+      - name: Invalidate cloudfront cache - Prod
+        env:
+          AWS_REGION: us-east-1
+          CLOUDFRONT_DISTRIBUTION_ID: E262M9HNAGO4PQ
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${CLOUDFRONT_DISTRIBUTION_ID} --paths "/features/features-v2.json"


### PR DESCRIPTION
This pull request updates the `.github/workflows/push-to-cdn.yaml` workflow to support publishing CDN assets to both Google Cloud and AWS (CloudFront/S3), as part of a migration from Google Cloud CDN to AWS CloudFront. The changes ensure that assets are uploaded and caches invalidated on both platforms for both staging and production environments. Temporary comments are added to highlight sections that can be removed once the migration is complete.

**CDN publishing and cache invalidation enhancements:**

* Added AWS steps to upload `features-v2.json` to S3 buckets (`nuclia-cdn-aws-global-stage-1` and `nuclia-cdn-aws-global-prod-1`) and invalidate CloudFront caches for both stage and prod environments.
* Updated GCP upload step names for clarity, distinguishing between stage and prod CDN uploads.

**Migration context and documentation:**

* Added clear comments marking the start and end of the GCP-specific steps, indicating they are temporary until the migration to CloudFront is complete. [[1]](diffhunk://#diff-9181f923817339d82b0e45923d965a68ae146af49275b43f92d54e6041f7fbabR23-R25) [[2]](diffhunk://#diff-9181f923817339d82b0e45923d965a68ae146af49275b43f92d54e6041f7fbabR59-R100)