### PR TITLE
Open new region eu-central-1

### DIFF
--- a/features-v2.json
+++ b/features-v2.json
@@ -248,7 +248,7 @@
   "application_zones": {
     "rollout": 100,
     "variants": {
-      "blocklist": ["aws-eu-south-2-1", "aws-eu-central-1-1"]
+      "blocklist": ["aws-eu-south-2-1"]
     }
   },
   "application_allow-kb-management-from-nua-key": {


### PR DESCRIPTION
This pull request makes a minor update to the `features-v2.json` configuration by removing the `"aws-eu-central-1-1"` region from the `blocklist` for the `application_zones` feature. This change will allow the feature to be available in the previously blocked region.